### PR TITLE
fix: move to workspace before clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ clean:
 		$(MAKE) -C Linux_for_Tegra/source nvidia-dtbs-clean
 
 distclean: clean
-	./edk2_docker edkrepo clean
+	cd c200 && ./../edk2_docker edkrepo clean
 	./edk2_docker edkrepo manifest-repos remove nvidia
 	rm -rf c200/ Linux_for_Tegra Jetson_Linux_R$(RELEASE)_aarch64.tbz2
 


### PR DESCRIPTION
Running `make distclean` gives the following error: Error: The current directory does not appear to be a valid workspace.

The workspace is cloned to `c200` directory[0]. Running command `./edk2_docker edkrepo clean` in c200 directory to fix the error.

[0]: https://github.com/radxa/c200-bootupd/blob/42e88ed13950710c034400067d599d8bbd9cab00/Makefile#L53